### PR TITLE
Use kebab-case names for test functions

### DIFF
--- a/t/01-connect.t
+++ b/t/01-connect.t
@@ -6,6 +6,6 @@ use Test;
 
 plan 1;
 
-dies_ok { Redis.new('127.0.0.1:0') }
+dies-ok { Redis.new('127.0.0.1:0') }
 
 # vim: ft=perl6

--- a/t/02-connection.t
+++ b/t/02-connection.t
@@ -9,10 +9,10 @@ $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
 
 plan 4;
 
-#dies_ok { $r.auth("WRONG PASSWORD"); }
-is_deeply $r.echo("Hello World!"), "Hello World!";
-is_deeply $r.ping, True;
-is_deeply $r.select(2), True;
-is_deeply $r.quit, True;
+#dies-ok { $r.auth("WRONG PASSWORD"); }
+is-deeply $r.echo("Hello World!"), "Hello World!";
+is-deeply $r.ping, True;
+is-deeply $r.select(2), True;
+is-deeply $r.quit, True;
 
 # vim: ft=perl6

--- a/t/02-hashes.t
+++ b/t/02-hashes.t
@@ -16,30 +16,30 @@ if $r.info<redis_version> gt "2.6" {
 
 # hset & hget & hmset & hmget & hsetnx
 $r.hdel("hash", "field1");
-is_deeply $r.hset("hash", "field1", 1), True;
-is_deeply $r.hsetnx("hash", "field1", 1), False;
-is_deeply $r.hget("hash", "field1"), "1";
-is_deeply $r.hmset("hash", "key", "value", key2 => "value2"), True;
-is_deeply $r.hmget("hash", "key", "key2"), ["value", "value2"];
+is-deeply $r.hset("hash", "field1", 1), True;
+is-deeply $r.hsetnx("hash", "field1", 1), False;
+is-deeply $r.hget("hash", "field1"), "1";
+is-deeply $r.hmset("hash", "key", "value", key2 => "value2"), True;
+is-deeply $r.hmget("hash", "key", "key2"), ["value", "value2"];
 
 # hdel & hexists
-is_deeply $r.hdel("hash", "field1", "key"), 2;
-is_deeply $r.hexists("hash", "field1"), False;
+is-deeply $r.hdel("hash", "field1", "key"), 2;
+is-deeply $r.hexists("hash", "field1"), False;
 
 # hgetall
 $r.hset("hash", "count", 1);
-is_deeply $r.hgetall("hash"), {key2 => "value2", count => "1"};
+is-deeply $r.hgetall("hash"), {key2 => "value2", count => "1"};
 
 # hincrby & hincrbyfloat
-is_deeply $r.hincrby("hash", "count", 10), 11;
+is-deeply $r.hincrby("hash", "count", 10), 11;
 if $r.info<redis_version> gt "2.6" {
-    is_deeply $r.hincrbyfloat("hash", "count", 10.1), 21.1;
+    is-deeply $r.hincrbyfloat("hash", "count", 10.1), 21.1;
 }
 
 # hkeys & hlen & hvals
-is_deeply $r.hkeys("hash"), ["key2", "count"];
-is_deeply $r.hlen("hash"), 2;
+is-deeply $r.hkeys("hash"), ["key2", "count"];
+is-deeply $r.hlen("hash"), 2;
 $r.hset("hash", "count", 10);
-is_deeply $r.hvals("hash"), ["value2", "10"];
+is-deeply $r.hvals("hash"), ["value2", "10"];
 
 # vim: ft=perl6

--- a/t/02-keys.t
+++ b/t/02-keys.t
@@ -16,44 +16,44 @@ if $r.info<redis_version> gt "2.6" {
 }
 
 # del
-is_deeply $r.del("key", "key2", "does_not_exists"), 0;
+is-deeply $r.del("key", "key2", "does_not_exists"), 0;
 
 # dump & restore
 if $r.info<redis_version> gt "2.6" {
     $r.set("key", "value");
     my $serialized = $r.dump("key");
     $r.del("newkey");
-    is_deeply $r.restore("newkey", 100, $serialized), True;
-    is_deeply $r.get("newkey"), "value";
+    is-deeply $r.restore("newkey", 100, $serialized), True;
+    is-deeply $r.get("newkey"), "value";
 }
 
 # exists
 $r.set("key", "value");
-is_deeply $r.exists("key"), True;
-is_deeply $r.exists("does_not_exists"), False;
+is-deeply $r.exists("key"), True;
+is-deeply $r.exists("does_not_exists"), False;
 
 # expire & persist & pexpire & expireat & pexpireat & pttl & ttl
 if $r.info<redis_version> gt "2.6" {
-    is_deeply $r.expire("key", 100), True;
+    is-deeply $r.expire("key", 100), True;
     ok $r.ttl("key") <= 100;
     ok $r.persist("key");
-    is_deeply $r.ttl("key"), -1;
-    is_deeply $r.pexpire("key", 100000), True;
-    is_deeply $r.expireat("key", 100), True;
-    is_deeply $r.ttl("key"), -1;
-    is_deeply $r.pexpireat("key", 1), False;
-    is_deeply $r.pttl("key"), -1;
+    is-deeply $r.ttl("key"), -1;
+    is-deeply $r.pexpire("key", 100000), True;
+    is-deeply $r.expireat("key", 100), True;
+    is-deeply $r.ttl("key"), -1;
+    is-deeply $r.pexpireat("key", 1), False;
+    is-deeply $r.pttl("key"), -1;
 } else {
-    is_deeply $r.expire("key", 100), True;
+    is-deeply $r.expire("key", 100), True;
     ok $r.ttl("key") <= 100;
     ok $r.persist("key");
-    is_deeply $r.ttl("key"), -1;
+    is-deeply $r.ttl("key"), -1;
 }
 
 # keys
 $r.set("pattern1", 1);
 $r.set("pattern2", 2);
-is_deeply $r.keys("pattern*"), ["pattern1", "pattern2"];
+is-deeply $r.keys("pattern*"), ["pattern1", "pattern2"];
 
 # migrate TODO
 
@@ -61,23 +61,23 @@ is_deeply $r.keys("pattern*"), ["pattern1", "pattern2"];
 
 # object
 $r.set("key", "value");
-is_deeply $r.object("refcount", "key"), 1;
+is-deeply $r.object("refcount", "key"), 1;
 
 # randomkey
-is_deeply $r.randomkey().WHAT.gist, "Str()";
+is-deeply $r.randomkey().WHAT.gist, "Str()";
 
 # rename
-is_deeply $r.rename("key", "newkey"), True;
+is-deeply $r.rename("key", "newkey"), True;
 
 # renamenx
-dies_ok { $r.renamenx("does_not_exists", "newkey"); }
+dies-ok { $r.renamenx("does_not_exists", "newkey"); }
 
 # sort TODO
 #say $r.sort("key", :desc);
 
 # type
 $r.set("key", "value");
-is_deeply $r.type("key"), "string";
-is_deeply $r.type("does_not_exists"), "none";
+is-deeply $r.type("key"), "string";
+is-deeply $r.type("does_not_exists"), "none";
 
 # vim: ft=perl6

--- a/t/02-pub&sub.t
+++ b/t/02-pub&sub.t
@@ -11,4 +11,4 @@ $r.flushall;
 plan 1;
 
 # TODO 
-is_deeply $r.publish("queue", "data"), 0;
+is-deeply $r.publish("queue", "data"), 0;

--- a/t/02-server.t
+++ b/t/02-server.t
@@ -9,8 +9,8 @@ $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
 
 plan 3;
 
-is_deeply $r.flushall(), True;
+is-deeply $r.flushall(), True;
 
-is_deeply $r.flushdb(), True;
+is-deeply $r.flushdb(), True;
 
 ok $r.info.WHAT === Hash;

--- a/t/02-transactions.t
+++ b/t/02-transactions.t
@@ -11,13 +11,13 @@ $r.flushall;
 plan 5;
 
 # multi->...->exec
-is_deeply $r.multi(), True;
+is-deeply $r.multi(), True;
 $r.set("key", "value");
 $r.set("key2", "value2");
-is_deeply $r.exec(), ["OK", "OK"];
+is-deeply $r.exec(), ["OK", "OK"];
 
 # multi->...->discard
-is_deeply $r.multi(), True;
+is-deeply $r.multi(), True;
 $r.set("key2", "value3");
-is_deeply $r.discard(), True;
-is_deeply $r.get("key2"), "value2";
+is-deeply $r.discard(), True;
+is-deeply $r.get("key2"), "value2";

--- a/t/03-binary.t
+++ b/t/03-binary.t
@@ -12,5 +12,5 @@ plan 2;
 
 # arbitary binary string 
 my Buf $binary = Buf.new(1,2,3,129);
-is_deeply $r.set("key", $binary), True;
-is_deeply $r.get("key"), $binary;
+is-deeply $r.set("key", $binary), True;
+is-deeply $r.get("key"), $binary;

--- a/t/03-multibytes.t
+++ b/t/03-multibytes.t
@@ -13,4 +13,4 @@ plan 1;
 # bug: multi-bytes chars and \r\n in data
 my $str = "中文 string contains newlines\r\n";
 $r.set("key", $str);
-is_deeply $r.get("key"), $str;
+is-deeply $r.get("key"), $str;

--- a/t/04-exec-any-commands.t
+++ b/t/04-exec-any-commands.t
@@ -9,4 +9,4 @@ $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
 
 plan 1;
 
-is_deeply $r.exec_command("CONFIG GET", "timeout"), ["timeout", "1"];
+is-deeply $r.exec_command("CONFIG GET", "timeout"), ["timeout", "1"];


### PR DESCRIPTION
The test function names with underscores are deprecated in favour of the
kebab-case equivalents.  The old function names will be removed in the
2015.09 release of Rakudo.  This change updates all tests to use the new
function names.