### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,13 +1,16 @@
 {
-    "perl" : "6.*",
-    "name" : "Redis",
-    "version" : "0.1.0",
-    "description" : "A Perl6 binding for Redis",
-    "provides" : {
-        "Redis" : "lib/Redis.pm"
-    },
-    "author" : "Yecheng Fu",
-    "depends" : [],
-    "source-type": "git",
-    "source-url" : "git://github.com/Cofyc/perl6-redis.git"
+  "name": "Redis",
+  "source-url": "git://github.com/Cofyc/perl6-redis.git",
+  "perl": "6.*",
+  "source-type": "git",
+  "author": "Yecheng Fu",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "Redis": "lib/Redis.pm"
+  },
+  "version": "0.1.0",
+  "description": "A Perl6 binding for Redis"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license