### PR TITLE
Catchup fixes

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,10 +7,13 @@
   "depends": [
     
   ],
+  "test-depends" : [
+      "File::Which"
+  ],
   "license": "Artistic-2.0",
   "provides": {
     "Redis": "lib/Redis.pm"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Perl6 binding for Redis"
 }

--- a/README.md
+++ b/README.md
@@ -11,23 +11,26 @@ Synopsis
 
 Build & Test & Install
 ======================
-    
-First, please get 'ufo' from <http://github.com/masak/ufo> , then run:
 
-    $ ufo
-    $ make
-    $ make test     # run `redis-server t/redis.conf` in another terminal first
-    $ make install
+Testing this will require redis-server to be installed on your machine.
+The tests will start their own version of the redis server on a different
+port so as not to interfere with a running server.  If no redis-server
+can be found on your machine the tests will be skipped so you will still
+be able to install this module.
 
-Install with Panda
-==================
+Assuming you have a working rakudo perl 6 installation then you should be
+able to install this with zef:
 
-    $ panda install --notests Redis # unit tests need Redis server
+    zef install Redis
+
+or if you have a local copy of the library:
+
+    zef install .
 
 Unit Tests
 ==========
 
-    Tested agaist Redis version 2.4.16 and 2.5.12.
+    Tested agaist Redis version 2.4.16, 2.5.12 and 4.0.9
 
 Docs
 ====

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -142,7 +142,7 @@ method !pack_command(*@args) returns Buf {
 }
 
 method exec_command(Str $command, *@args) returns Any {
-    @args.unshift($command.split(" "));
+    @args.prepend($command.split(" "));
     $.conn.write(self!pack_command(|@args));
     my Buf $remainder = Buf.new;
     return self!parse_response(self!read_response($remainder), $command);

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -752,8 +752,10 @@ method zinterstore(Str $destination, *@keys, :WEIGHTS(@weights)?, :AGGREGATE(@ag
 }
 
 # TODO return array of paires if WITHSCORES is set
-method zrange(Str $key, Int $start, Int $stop, :WITHSCORES($withscores)?) {
-    return self.exec_command("ZRANGE", $key, $start, $stop, $withscores.defined ?? "WITHSCORES" !! Nil);
+method zrange(Str $key, Int $start, Int $stop, :WITHSCORES($withscores)) {
+    my @args = $key, $start, $stop;
+    @args.append('WITHSCORES') if $withscores.defined;
+    return self.exec_command("ZRANGE", |@args);
 }
 
 # TODO return array of paires if WITHSCORES is set
@@ -761,12 +763,12 @@ method zrangebyscore(Str $key, Real $min, Real $max, :WITHSCORES($withscores), I
     if ($offset.defined and !$count.defined) or (!$offset.defined and $count.defined) {
         die "`offset` and `count` must both be specified.";
     }
-    return self.exec_command("ZRANGEBYSCORE", $key, $min, $max,
-        $withscores.defined ?? "WITHSCORES" !! Nil,
-        ($offset.defined and $count.defined) ?? "LIMIT" !! Nil,
-        $offset.defined ?? $offset !! Nil,
-        $count.defined ?? $count !! Nil
-    );
+    my @args = $key, $min, $max;
+    @args.append("WITHSCORES") if $withscores.defined;
+    @args.append("LIMIT") if ($offset.defined and $count.defined);
+    @args.append($offset) if $offset.defined;
+    @args.append($count) if $count.defined;
+    return self.exec_command("ZRANGEBYSCORE", |@args);
 }
 
 method zrank(Str $key, $member) returns Any {

--- a/t/02-connection.t
+++ b/t/02-connection.t
@@ -4,15 +4,27 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+use Test::SpawnRedisServer;
 
 plan 4;
 
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+
+
 #dies-ok { $r.auth("WRONG PASSWORD"); }
-is-deeply $r.echo("Hello World!"), "Hello World!";
-is-deeply $r.ping, True;
-is-deeply $r.select(2), True;
-is-deeply $r.quit, True;
+    is-deeply $r.echo("Hello World!"), "Hello World!";
+    is-deeply $r.ping, True;
+    is-deeply $r.select(2), True;
+    is-deeply $r.quit, True;
+
+}
+else {
+    skip-rest "no redis-server";
+}
 
 # vim: ft=perl6

--- a/t/02-hashes.t
+++ b/t/02-hashes.t
@@ -4,42 +4,54 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
-if $r.info<redis_version> gt "2.6" {
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
+
+    if $r.info<redis_version> gt "2.6" {
+        plan 13;
+    } else {
+        plan 12;
+    }
+
+    # hset & hget & hmset & hmget & hsetnx
+    $r.hdel("hash", "field1");
+    is-deeply $r.hset("hash", "field1", 1), True, "hset";
+    is-deeply $r.hsetnx("hash", "field1", 1), False, "hsetnx";
+    is-deeply $r.hget("hash", "field1"), "1", "hget";
+    is-deeply $r.hmset("hash", "key", "value", key2 => "value2"), True, "hmset";
+    is-deeply $r.hmget("hash", "key", "key2"), ["value", "value2"], "hmget";
+
+    # hdel & hexists
+    is-deeply $r.hdel("hash", "field1", "key"), 2, 'hdel';
+    is-deeply $r.hexists("hash", "field1"), False, 'hexists';
+
+    # hgetall
+    $r.hset("hash", "count", 1);
+    is-deeply $r.hgetall("hash"), {key2 => "value2", count => "1"}, 'hgetall';
+
+    # hincrby & hincrbyfloat
+    is-deeply $r.hincrby("hash", "count", 10), 11, 'hincrby';
+    if $r.info<redis_version> gt "2.6" {
+        is-deeply $r.hincrbyfloat("hash", "count", 10.1), 21.1, 'hincrbyfloat';
+    }
+
+    # hkeys & hlen & hvals
+    is-deeply $r.hkeys("hash"), ["key2", "count"], 'hkeys';
+    is-deeply $r.hlen("hash"), 2, 'hlen';
+    $r.hset("hash", "count", 10);
+    is-deeply $r.hvals("hash"), ["value2", "10"], 'hvals';
+}
+else {
     plan 13;
-} else {
-    plan 12;
+    skip-rest "no redis-server";
 }
-
-# hset & hget & hmset & hmget & hsetnx
-$r.hdel("hash", "field1");
-is-deeply $r.hset("hash", "field1", 1), True, "hset";
-is-deeply $r.hsetnx("hash", "field1", 1), False, "hsetnx";
-is-deeply $r.hget("hash", "field1"), "1", "hget";
-is-deeply $r.hmset("hash", "key", "value", key2 => "value2"), True, "hmset";
-is-deeply $r.hmget("hash", "key", "key2"), ["value", "value2"], "hmget";
-
-# hdel & hexists
-is-deeply $r.hdel("hash", "field1", "key"), 2, 'hdel';
-is-deeply $r.hexists("hash", "field1"), False, 'hexists';
-
-# hgetall
-$r.hset("hash", "count", 1);
-is-deeply $r.hgetall("hash"), {key2 => "value2", count => "1"}, 'hgetall';
-
-# hincrby & hincrbyfloat
-is-deeply $r.hincrby("hash", "count", 10), 11, 'hincrby';
-if $r.info<redis_version> gt "2.6" {
-    is-deeply $r.hincrbyfloat("hash", "count", 10.1), 21.1, 'hincrbyfloat';
-}
-
-# hkeys & hlen & hvals
-is-deeply $r.hkeys("hash"), ["key2", "count"], 'hkeys';
-is-deeply $r.hlen("hash"), 2, 'hlen';
-$r.hset("hash", "count", 10);
-is-deeply $r.hvals("hash"), ["value2", "10"], 'hvals';
 
 # vim: ft=perl6

--- a/t/02-hashes.t
+++ b/t/02-hashes.t
@@ -16,11 +16,11 @@ if $r.info<redis_version> gt "2.6" {
 
 # hset & hget & hmset & hmget & hsetnx
 $r.hdel("hash", "field1");
-is-deeply $r.hset("hash", "field1", 1), True;
-is-deeply $r.hsetnx("hash", "field1", 1), False;
-is-deeply $r.hget("hash", "field1"), "1";
-is-deeply $r.hmset("hash", "key", "value", key2 => "value2"), True;
-is-deeply $r.hmget("hash", "key", "key2"), ["value", "value2"];
+is-deeply $r.hset("hash", "field1", 1), True, "hset";
+is-deeply $r.hsetnx("hash", "field1", 1), False, "hsetnx";
+is-deeply $r.hget("hash", "field1"), "1", "hget";
+is-deeply $r.hmset("hash", "key", "value", key2 => "value2"), True, "hmset";
+is-deeply $r.hmget("hash", "key", "key2"), ["value", "value2"], "hmget";
 
 # hdel & hexists
 is-deeply $r.hdel("hash", "field1", "key"), 2;

--- a/t/02-hashes.t
+++ b/t/02-hashes.t
@@ -23,23 +23,23 @@ is-deeply $r.hmset("hash", "key", "value", key2 => "value2"), True, "hmset";
 is-deeply $r.hmget("hash", "key", "key2"), ["value", "value2"], "hmget";
 
 # hdel & hexists
-is-deeply $r.hdel("hash", "field1", "key"), 2;
-is-deeply $r.hexists("hash", "field1"), False;
+is-deeply $r.hdel("hash", "field1", "key"), 2, 'hdel';
+is-deeply $r.hexists("hash", "field1"), False, 'hexists';
 
 # hgetall
 $r.hset("hash", "count", 1);
-is-deeply $r.hgetall("hash"), {key2 => "value2", count => "1"};
+is-deeply $r.hgetall("hash"), {key2 => "value2", count => "1"}, 'hgetall';
 
 # hincrby & hincrbyfloat
-is-deeply $r.hincrby("hash", "count", 10), 11;
+is-deeply $r.hincrby("hash", "count", 10), 11, 'hincrby';
 if $r.info<redis_version> gt "2.6" {
-    is-deeply $r.hincrbyfloat("hash", "count", 10.1), 21.1;
+    is-deeply $r.hincrbyfloat("hash", "count", 10.1), 21.1, 'hincrbyfloat';
 }
 
 # hkeys & hlen & hvals
-is-deeply $r.hkeys("hash"), ["key2", "count"];
-is-deeply $r.hlen("hash"), 2;
+is-deeply $r.hkeys("hash"), ["key2", "count"], 'hkeys';
+is-deeply $r.hlen("hash"), 2, 'hlen';
 $r.hset("hash", "count", 10);
-is-deeply $r.hvals("hash"), ["value2", "10"];
+is-deeply $r.hvals("hash"), ["value2", "10"], 'hvals';
 
 # vim: ft=perl6

--- a/t/02-keys.t
+++ b/t/02-keys.t
@@ -40,9 +40,9 @@ if $r.info<redis_version> gt "2.6" {
     is-deeply $r.ttl("key"), -1;
     is-deeply $r.pexpire("key", 100000), True;
     is-deeply $r.expireat("key", 100), True;
-    is-deeply $r.ttl("key"), -1;
+    is $r.ttl("key"), $r.info<redis_version> ge "2.8" ?? -2 !! -1;
     is-deeply $r.pexpireat("key", 1), False;
-    is-deeply $r.pttl("key"), -1;
+    is $r.pttl("key"), $r.info<redis_version> ge "2.8" ?? -2 !! -1;
 } else {
     is-deeply $r.expire("key", 100), True;
     ok $r.ttl("key") <= 100;

--- a/t/02-keys.t
+++ b/t/02-keys.t
@@ -4,80 +4,91 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
+
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
 
-if $r.info<redis_version> gt "2.6" {
-    plan 21;
-} else {
-    plan 14;
-}
+    if $r.info<redis_version> gt "2.6" {
+        plan 21;
+    } else {
+        plan 14;
+    }
 
-# del
-is-deeply $r.del("key", "key2", "does_not_exists"), 0;
+    # del
+    is-deeply $r.del("key", "key2", "does_not_exists"), 0;
 
-# dump & restore
-if $r.info<redis_version> gt "2.6" {
+    # dump & restore
+    if $r.info<redis_version> gt "2.6" {
+        $r.set("key", "value");
+        my $serialized = $r.dump("key");
+        $r.del("newkey");
+        is-deeply $r.restore("newkey", 100, $serialized), True;
+        is-deeply $r.get("newkey"), "value";
+    }
+
+    # exists
     $r.set("key", "value");
-    my $serialized = $r.dump("key");
-    $r.del("newkey");
-    is-deeply $r.restore("newkey", 100, $serialized), True;
-    is-deeply $r.get("newkey"), "value";
+    is-deeply $r.exists("key"), True;
+    is-deeply $r.exists("does_not_exists"), False;
+
+    # expire & persist & pexpire & expireat & pexpireat & pttl & ttl
+    if $r.info<redis_version> gt "2.6" {
+        is-deeply $r.expire("key", 100), True;
+        ok $r.ttl("key") <= 100;
+        ok $r.persist("key");
+        is-deeply $r.ttl("key"), -1;
+        is-deeply $r.pexpire("key", 100000), True;
+        is-deeply $r.expireat("key", 100), True;
+        is $r.ttl("key"), $r.info<redis_version> ge "2.8" ?? -2 !! -1;
+        is-deeply $r.pexpireat("key", 1), False;
+        is $r.pttl("key"), $r.info<redis_version> ge "2.8" ?? -2 !! -1;
+    } else {
+        is-deeply $r.expire("key", 100), True;
+        ok $r.ttl("key") <= 100;
+        ok $r.persist("key");
+        is-deeply $r.ttl("key"), -1;
+    }
+
+    # keys
+    $r.set("pattern1", 1);
+    $r.set("pattern2", 2);
+    is-deeply $r.keys("pattern*").sort, ("pattern1", "pattern2");
+
+    # migrate TODO
+
+    # move TODO
+
+    # object
+    $r.set("key", "value");
+    is-deeply $r.object("refcount", "key"), 1;
+
+    # randomkey
+    is-deeply $r.randomkey().WHAT.gist, "(Str)";
+
+    # rename
+    is-deeply $r.rename("key", "newkey"), True;
+
+    # renamenx
+    dies-ok { $r.renamenx("does_not_exists", "newkey"); }
+
+    # sort TODO
+    #say $r.sort("key", :desc);
+
+    # type
+    $r.set("key", "value");
+    is-deeply $r.type("key"), "string";
+    is-deeply $r.type("does_not_exists"), "none";
 }
-
-# exists
-$r.set("key", "value");
-is-deeply $r.exists("key"), True;
-is-deeply $r.exists("does_not_exists"), False;
-
-# expire & persist & pexpire & expireat & pexpireat & pttl & ttl
-if $r.info<redis_version> gt "2.6" {
-    is-deeply $r.expire("key", 100), True;
-    ok $r.ttl("key") <= 100;
-    ok $r.persist("key");
-    is-deeply $r.ttl("key"), -1;
-    is-deeply $r.pexpire("key", 100000), True;
-    is-deeply $r.expireat("key", 100), True;
-    is $r.ttl("key"), $r.info<redis_version> ge "2.8" ?? -2 !! -1;
-    is-deeply $r.pexpireat("key", 1), False;
-    is $r.pttl("key"), $r.info<redis_version> ge "2.8" ?? -2 !! -1;
-} else {
-    is-deeply $r.expire("key", 100), True;
-    ok $r.ttl("key") <= 100;
-    ok $r.persist("key");
-    is-deeply $r.ttl("key"), -1;
+else {
+    plan 21;
+    skip-rest "no redis-server";
 }
-
-# keys
-$r.set("pattern1", 1);
-$r.set("pattern2", 2);
-is-deeply $r.keys("pattern*").sort, ("pattern1", "pattern2");
-
-# migrate TODO
-
-# move TODO
-
-# object
-$r.set("key", "value");
-is-deeply $r.object("refcount", "key"), 1;
-
-# randomkey
-is-deeply $r.randomkey().WHAT.gist, "(Str)";
-
-# rename
-is-deeply $r.rename("key", "newkey"), True;
-
-# renamenx
-dies-ok { $r.renamenx("does_not_exists", "newkey"); }
-
-# sort TODO
-#say $r.sort("key", :desc);
-
-# type
-$r.set("key", "value");
-is-deeply $r.type("key"), "string";
-is-deeply $r.type("does_not_exists"), "none";
 
 # vim: ft=perl6

--- a/t/02-lists.t
+++ b/t/02-lists.t
@@ -4,39 +4,50 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
 plan 16;
 
-# TODO blpop & brpop & brpoplpush
 
-# lindex & lpush & llen & linsert & lrange & lpushx
-$r.del("mylist");
-is-deeply $r.lpush("mylist", "World", "Hello"), 2;
-is-deeply $r.lindex("mylist", 1), "World";
-is-deeply $r.lindex("mylist", 2), Any;
-is-deeply $r.llen("mylist"), 2;
-dies-ok { $r.linsert("mylist", "OK", "World", ", "); }
-is-deeply $r.linsert("mylist", "BEFORE", "World", ", "), 3;
-is-deeply $r.lrange("mylist", 0, 2), ["Hello", ", ", "World"];
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
-# lpushx & lpop & rpop
-is-deeply $r.lpushx("mylist", 1), 4;
-is-deeply $r.lpop("mylist"), "1";
-is-deeply $r.rpop("mylist"), "World";
 
-# lrem & lset & ltrim
-$r.del("mylist");
-$r.lpush("mylist", 1, 2, 3, 4);
-is-deeply $r.lset("mylist", 0, 1), True;
-is-deeply $r.lrem("mylist", 0, 1), 2;
-is-deeply $r.ltrim("mylist", 0, 1), True;
+    # TODO blpop & brpop & brpoplpush
 
-# rpoplpush & rpush & rpushx
-is-deeply $r.rpoplpush("mylist", "newlist"), "2";
-is-deeply $r.rpush("mylist", 2), 2;
-is-deeply $r.rpushx("mylist", 2), 3;
+    # lindex & lpush & llen & linsert & lrange & lpushx
+    $r.del("mylist");
+    is-deeply $r.lpush("mylist", "World", "Hello"), 2;
+    is-deeply $r.lindex("mylist", 1), "World";
+    is-deeply $r.lindex("mylist", 2), Any;
+    is-deeply $r.llen("mylist"), 2;
+    dies-ok { $r.linsert("mylist", "OK", "World", ", "); }
+    is-deeply $r.linsert("mylist", "BEFORE", "World", ", "), 3;
+    is-deeply $r.lrange("mylist", 0, 2), ["Hello", ", ", "World"];
 
+    # lpushx & lpop & rpop
+    is-deeply $r.lpushx("mylist", 1), 4;
+    is-deeply $r.lpop("mylist"), "1";
+    is-deeply $r.rpop("mylist"), "World";
+
+    # lrem & lset & ltrim
+    $r.del("mylist");
+    $r.lpush("mylist", 1, 2, 3, 4);
+    is-deeply $r.lset("mylist", 0, 1), True;
+    is-deeply $r.lrem("mylist", 0, 1), 2;
+    is-deeply $r.ltrim("mylist", 0, 1), True;
+
+    # rpoplpush & rpush & rpushx
+    is-deeply $r.rpoplpush("mylist", "newlist"), "2";
+    is-deeply $r.rpush("mylist", 2), 2;
+    is-deeply $r.rpushx("mylist", 2), 3;
+}
+else {
+    skip-rest "no redis-server";
+}
 # vim: ft=perl6

--- a/t/02-pub&sub.t
+++ b/t/02-pub&sub.t
@@ -4,11 +4,23 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
-
 plan 1;
 
-# TODO 
-is-deeply $r.publish("queue", "data"), 0;
+use Test::SpawnRedisServer;
+
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
+
+
+    # TODO
+    is-deeply $r.publish("queue", "data"), 0;
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/02-scripting.t
+++ b/t/02-scripting.t
@@ -4,24 +4,37 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
-if $r.info<redis_version> gt "2.6" {
-    plan 5;
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
 
-    $r.set("key", 1);
-    is-deeply $r.eval("return redis.call('get', 'key')", 0), "1";
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
-    is-deeply $r.script_flush(), True;
+    if $r.info<redis_version> gt "2.6" {
+        plan 5;
 
-    dies-ok { $r.script_kill() };
+        $r.set("key", 1);
+        is-deeply $r.eval("return redis.call('get', 'key')", 0), "1";
 
-    my $sha = $r.script_load("return redis.call('get', 'key')");
-    is-deeply $r.script_exists($sha, "unknown"), [1, 0];
+        is-deeply $r.script_flush(), True;
 
-    is-deeply $r.evalsha($sha, 0), "1";
-} else {
-    done;
+        dies-ok { $r.script_kill() };
+
+        my $sha = $r.script_load("return redis.call('get', 'key')");
+        is-deeply $r.script_exists($sha, "unknown"), [1, 0];
+
+        is-deeply $r.evalsha($sha, 0), "1";
+    } else {
+        plan 1;
+        skip-rest "scripting not available on this redis-server";
+    }
+}
+else {
+    plan 1;
+    skip-rest "no redis-server";
 }

--- a/t/02-server.t
+++ b/t/02-server.t
@@ -4,13 +4,25 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+use Test::SpawnRedisServer;
 
 plan 3;
 
-is-deeply $r.flushall(), True;
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
 
-is-deeply $r.flushdb(), True;
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
 
-ok $r.info.WHAT === Hash;
+
+    is-deeply $r.flushall(), True;
+
+    is-deeply $r.flushdb(), True;
+
+    ok $r.info.WHAT === Hash;
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/02-sets.t
+++ b/t/02-sets.t
@@ -4,37 +4,49 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
 plan 15;
 
-is-deeply $r.sadd("set1", 1, 2, 3, 4), 4;
-is-deeply $r.scard("set1"), 4;
-$r.sadd("set2", 3, 4);
-is-deeply $r.sdiff("set1", "set2"), ["1", "2"];
-is-deeply $r.sdiffstore("set_diff", "set1", "set2"), 2;
-is-deeply $r.smembers("set_diff"), ["1", "2"];
-is-deeply $r.sinter("set1", "set2"), ["3", "4"];
-is-deeply $r.sinterstore("set_inter", "set2"), 2;
-is-deeply $r.sismember("set_inter", 3), True;
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
 
-# smove
-is-deeply $r.smove("set_inter", "set_diff", 3), True;
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
-# spop
-ok $r.spop("set_diff") eq any("1", "2", "3");
-is-deeply $r.scard("set_diff"), 2;
 
-# srandmember
-ok $r.srandmember("set_diff") eq any("1", "2", "3");
+    is-deeply $r.sadd("set1", 1, 2, 3, 4), 4;
+    is-deeply $r.scard("set1"), 4;
+    $r.sadd("set2", 3, 4);
+    is-deeply $r.sdiff("set1", "set2"), ["1", "2"];
+    is-deeply $r.sdiffstore("set_diff", "set1", "set2"), 2;
+    is-deeply $r.smembers("set_diff"), ["1", "2"];
+    is-deeply $r.sinter("set1", "set2"), ["3", "4"];
+    is-deeply $r.sinterstore("set_inter", "set2"), 2;
+    is-deeply $r.sismember("set_inter", 3), True;
 
-# srem
-is-deeply $r.srem("set_inter", "3", "4"), 0;
+    # smove
+    is-deeply $r.smove("set_inter", "set_diff", 3), True;
 
-# sunion & sunionstore
-is-deeply $r.sunion("set1", "set2"), ["1", "2", "3", "4"];
-is-deeply $r.sunionstore("set_union", "set1", "set2"), 4;
+    # spop
+    ok $r.spop("set_diff") eq any("1", "2", "3");
+    is-deeply $r.scard("set_diff"), 2;
+
+    # srandmember
+    ok $r.srandmember("set_diff") eq any("1", "2", "3");
+
+    # srem
+    is-deeply $r.srem("set_inter", "3", "4"), 0;
+
+    # sunion & sunionstore
+    is-deeply $r.sunion("set1", "set2"), ["1", "2", "3", "4"];
+    is-deeply $r.sunionstore("set_union", "set1", "set2"), 4;
+}
+else {
+    skip-rest "no redis-server";
+}
 
 # vim: ft=perl6

--- a/t/02-sortedsets.t
+++ b/t/02-sortedsets.t
@@ -18,7 +18,7 @@ is-deeply $r.zcard("myzset"), 4;
 
 is-deeply $r.zcount("myzset", 2, 3), 2;
 
-is-deeply $r.zincrby("myzset", 1.1, "THREE"), 4.1;
+is-approx $r.zincrby("myzset", 1.1, "THREE"), 4.1;
 
 # zinterstore & zrange & zrangebyscore & zrevrange & zrevrangebyscore
 $r.zadd("zset1", "one" => 1, "two" => 2);
@@ -38,7 +38,7 @@ $r.flushall;
 $r.zadd("myzset", one=>1, two=>2, three=>3, four=>4);
 is-deeply $r.zrank("myzset", "one"), 0;
 is-deeply $r.zrevrank("myzset", "one"), 3;
-is-deeply $r.zrank("myzset", "other"), Nil;
+nok $r.zrank("myzset", "other").defined, "zrank with non-defined key";
 is-deeply $r.zrem("myzset", "other", "one"), 1;
 is-deeply $r.zremrangbyrank("myzset", 0, 1), 2;
 is-deeply $r.zremrangebyscore("myzset", 2, 3), 0;

--- a/t/02-sortedsets.t
+++ b/t/02-sortedsets.t
@@ -4,49 +4,60 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
 plan 23;
 
-is-deeply $r.zadd("myzset", ONE => 1, TWO => 2, THREE=> 3), 3;
-is-deeply $r.zadd("myzset", "ZERO", 0, "ONE" => 1, TWO => 2, THREE=> 3), 1;
-dies-ok { $r.zadd("myzset", "ZERO", ONE => 1, TWO => 2, THREE=> 3) }
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
 
-is-deeply $r.zcard("myzset"), 4;
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
-is-deeply $r.zcount("myzset", 2, 3), 2;
 
-is-approx $r.zincrby("myzset", 1.1, "THREE"), 4.1;
+    is-deeply $r.zadd("myzset", ONE => 1, TWO => 2, THREE=> 3), 3;
+    is-deeply $r.zadd("myzset", "ZERO", 0, "ONE" => 1, TWO => 2, THREE=> 3), 1;
+    dies-ok { $r.zadd("myzset", "ZERO", ONE => 1, TWO => 2, THREE=> 3) }
 
-# zinterstore & zrange & zrangebyscore & zrevrange & zrevrangebyscore
-$r.zadd("zset1", "one" => 1, "two" => 2);
-$r.zadd("zset2", "one" => 1, "two" => 2, "three" => 3);
-is-deeply $r.zinterstore("out", "zset1", "zset2", weights => (2,3)), 2;
-is-deeply $r.zinterstore("out", "zset1", "zset2", WEIGHTS => (2,3)), 2;
-is-deeply $r.zrange("out", 0, -1), ["one", "two"];
-is-deeply $r.zrange("out", 0, -1, :WITHSCORES), ["one", "5", "two", "10"];
-is-deeply $r.zrevrange("out", 0, -1, :WITHSCORES), ["two", "10", "one", "5"];
-is-deeply $r.zrangebyscore("out", 6, 10), ["two"];
-is-deeply $r.zrangebyscore("out", 6, 10, :WITHSCORES), ["two", "10"];
-is-deeply $r.zrangebyscore("out", 0, 10, :WITHSCORES, OFFSET=>0, COUNT=>1), ["one", "5"];
-is-deeply $r.zrevrangebyscore("out", 10, 0, :WITHSCORES, OFFSET=>0, COUNT=>1), ["two", "10"];
+    is-deeply $r.zcard("myzset"), 4;
 
-# zrank & zrem & zremrangbyrank & zrevrank
-$r.flushall;
-$r.zadd("myzset", one=>1, two=>2, three=>3, four=>4);
-is-deeply $r.zrank("myzset", "one"), 0;
-is-deeply $r.zrevrank("myzset", "one"), 3;
-nok $r.zrank("myzset", "other").defined, "zrank with non-defined key";
-is-deeply $r.zrem("myzset", "other", "one"), 1;
-is-deeply $r.zremrangbyrank("myzset", 0, 1), 2;
-is-deeply $r.zremrangebyscore("myzset", 2, 3), 0;
+    is-deeply $r.zcount("myzset", 2, 3), 2;
 
-# zscore & zunionstore
-$r.flushall;
-$r.zadd("myzset", one=>1, two=>2, three=>3, four=>4);
-$r.zadd("myzset2", five=>5, six=>6);
-is-deeply $r.zscore("myzset", "three"), 3;
-is-deeply $r.zunionstore("newset", "myzset", "myzset2"), 6;
+    is-approx $r.zincrby("myzset", 1.1, "THREE"), 4.1;
 
+    # zinterstore & zrange & zrangebyscore & zrevrange & zrevrangebyscore
+    $r.zadd("zset1", "one" => 1, "two" => 2);
+    $r.zadd("zset2", "one" => 1, "two" => 2, "three" => 3);
+    is-deeply $r.zinterstore("out", "zset1", "zset2", weights => (2,3)), 2;
+    is-deeply $r.zinterstore("out", "zset1", "zset2", WEIGHTS => (2,3)), 2;
+    is-deeply $r.zrange("out", 0, -1), ["one", "two"];
+    is-deeply $r.zrange("out", 0, -1, :WITHSCORES), ["one", "5", "two", "10"];
+    is-deeply $r.zrevrange("out", 0, -1, :WITHSCORES), ["two", "10", "one", "5"];
+    is-deeply $r.zrangebyscore("out", 6, 10), ["two"];
+    is-deeply $r.zrangebyscore("out", 6, 10, :WITHSCORES), ["two", "10"];
+    is-deeply $r.zrangebyscore("out", 0, 10, :WITHSCORES, OFFSET=>0, COUNT=>1), ["one", "5"];
+    is-deeply $r.zrevrangebyscore("out", 10, 0, :WITHSCORES, OFFSET=>0, COUNT=>1), ["two", "10"];
+
+    # zrank & zrem & zremrangbyrank & zrevrank
+    $r.flushall;
+    $r.zadd("myzset", one=>1, two=>2, three=>3, four=>4);
+    is-deeply $r.zrank("myzset", "one"), 0;
+    is-deeply $r.zrevrank("myzset", "one"), 3;
+    nok $r.zrank("myzset", "other").defined, "zrank with non-defined key";
+    is-deeply $r.zrem("myzset", "other", "one"), 1;
+    is-deeply $r.zremrangbyrank("myzset", 0, 1), 2;
+    is-deeply $r.zremrangebyscore("myzset", 2, 3), 0;
+
+    # zscore & zunionstore
+    $r.flushall;
+    $r.zadd("myzset", one=>1, two=>2, three=>3, four=>4);
+    $r.zadd("myzset2", five=>5, six=>6);
+    is-deeply $r.zscore("myzset", "three"), 3;
+    is-deeply $r.zunionstore("newset", "myzset", "myzset2"), 6;
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/02-strings.t
+++ b/t/02-strings.t
@@ -4,101 +4,112 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
-if $r.info<redis_version> gt "2.6" {
-    plan 35;
-} else {
-    plan 26;
-}
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
 
-# append
-$r.del("key");
-is-deeply $r.append("key", "Hello"), 5;
-is-deeply $r.append("key", " World"), 11;
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
-# bitcount
-if $r.info<redis_version> gt "2.6" {
-    $r.set("key", "foobar");
-    is-deeply $r.bitcount("key"), 26;
-    is-deeply $r.bitcount("key", 0, 0), 4;
-    is-deeply $r.bitcount("key", 1, 1), 6;
-}
+    if $r.info<redis_version> gt "2.6" {
+        plan 35;
+    } else {
+        plan 26;
+    }
 
-# bitop
-if $r.info<redis_version> gt "2.6" {
-    $r.set("key1", "foobar");
-    $r.set("key2", "abcdefg");
-    is-deeply $r.bitop("AND", "dest", "key1", "key2"), 7;
-}
+    # append
+    $r.del("key");
+    is-deeply $r.append("key", "Hello"), 5;
+    is-deeply $r.append("key", " World"), 11;
 
-# incr & decr & decrby & incrby
-$r.set("key2", 100);
-is-deeply $r.incr("key2"), 101;
-is-deeply $r.decr("key2"), 100;
-is-deeply $r.decrby("key2", 2), 98;
-is-deeply $r.incrby("key2", 3), 101;
+    # bitcount
+    if $r.info<redis_version> gt "2.6" {
+        $r.set("key", "foobar");
+        is-deeply $r.bitcount("key"), 26;
+        is-deeply $r.bitcount("key", 0, 0), 4;
+        is-deeply $r.bitcount("key", 1, 1), 6;
+    }
 
-# getbit
-is-deeply $r.getbit("key2", 2), 1;
+    # bitop
+    if $r.info<redis_version> gt "2.6" {
+        $r.set("key1", "foobar");
+        $r.set("key2", "abcdefg");
+        is-deeply $r.bitop("AND", "dest", "key1", "key2"), 7;
+    }
 
-# getrange
-$r.set("mykey", "This is a string");
-is-deeply $r.getrange("mykey", 0, 3), "This";
+    # incr & decr & decrby & incrby
+    $r.set("key2", 100);
+    is-deeply $r.incr("key2"), 101;
+    is-deeply $r.decr("key2"), 100;
+    is-deeply $r.decrby("key2", 2), 98;
+    is-deeply $r.incrby("key2", 3), 101;
 
-# getset
-$r.del("mycounter");
-is-deeply $r.incr("mycounter"), 1;
-is-deeply $r.getset("mycounter", 0), "1";
-is-deeply $r.get("mycounter"), "0";
+    # getbit
+    is-deeply $r.getbit("key2", 2), 1;
 
-# incrbyfloat
-if $r.info<redis_version> gt "2.6" {
-    $r.set("mykey", 10.50);
-    is-deeply $r.incrbyfloat("mykey", 0.1), 10.6;
-    $r.set("mykey", 5.0e3);
-    is-deeply $r.incrbyfloat("mykey", 2.0e2), 5200;
-}
+    # getrange
+    $r.set("mykey", "This is a string");
+    is-deeply $r.getrange("mykey", 0, 3), "This";
 
-# set & get
-is-deeply $r.set("key", "value"), True;
-is-deeply $r.get("key"), "value";
-is-deeply $r.get("does_not_exists"), Any;
-is-deeply $r.set("key2", 100), True;
-is-deeply $r.get("key2"), "100";
+    # getset
+    $r.del("mycounter");
+    is-deeply $r.incr("mycounter"), 1;
+    is-deeply $r.getset("mycounter", 0), "1";
+    is-deeply $r.get("mycounter"), "0";
 
-# mget
-$r.del("key", "key2");
-is-deeply $r.mset("key", "value", key2 => "value2"), True;
-is-deeply $r.mget("key", "key2"), ["value", "value2"];
-is-deeply $r.msetnx("key", "value", key2 => "value2"), 0;
+    # incrbyfloat
+    if $r.info<redis_version> gt "2.6" {
+        $r.set("mykey", 10.50);
+        is-deeply $r.incrbyfloat("mykey", 0.1), 10.6;
+        $r.set("mykey", 5.0e3);
+        is-deeply $r.incrbyfloat("mykey", 2.0e2), 5200;
+    }
 
-# psetex
-if $r.info<redis_version> gt "2.6" {
-    is-deeply $r.psetex("key", 100, "value"), True;
+    # set & get
+    is-deeply $r.set("key", "value"), True;
     is-deeply $r.get("key"), "value";
-    sleep(0.1);
-    is-deeply $r.get("key"), Any;
+    is-deeply $r.get("does_not_exists"), Any;
+    is-deeply $r.set("key2", 100), True;
+    is-deeply $r.get("key2"), "100";
+
+    # mget
+    $r.del("key", "key2");
+    is-deeply $r.mset("key", "value", key2 => "value2"), True;
+    is-deeply $r.mget("key", "key2"), ["value", "value2"];
+    is-deeply $r.msetnx("key", "value", key2 => "value2"), 0;
+
+    # psetex
+    if $r.info<redis_version> gt "2.6" {
+        is-deeply $r.psetex("key", 100, "value"), True;
+        is-deeply $r.get("key"), "value";
+        sleep(0.1);
+        is-deeply $r.get("key"), Any;
+    }
+
+    # setbit
+    $r.del("mykey");
+    is-deeply $r.setbit("mykey", 7, 1), 0;
+    is-deeply $r.setbit("mykey", 7, 0), 1;
+
+    # setex
+    is-deeply $r.setex("key", 1, "value"), True;
+
+    # setnx
+    is-deeply $r.setnx("key", "value"), False;
+
+    # setrange
+    is-deeply $r.setrange("key", 2, "123"), 5;
+    is-deeply $r.get("key"), "va123";
+
+    # strlen
+    is-deeply $r.strlen("key"), 5;
 }
-
-# setbit
-$r.del("mykey");
-is-deeply $r.setbit("mykey", 7, 1), 0;
-is-deeply $r.setbit("mykey", 7, 0), 1;
-
-# setex
-is-deeply $r.setex("key", 1, "value"), True;
-
-# setnx
-is-deeply $r.setnx("key", "value"), False;
-
-# setrange
-is-deeply $r.setrange("key", 2, "123"), 5;
-is-deeply $r.get("key"), "va123";
-
-# strlen
-is-deeply $r.strlen("key"), 5;
-
+else {
+    plan 25;
+    skip-rest "no redis-server";
+}
 # vim: ft=perl6

--- a/t/02-transactions.t
+++ b/t/02-transactions.t
@@ -4,20 +4,31 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
 plan 5;
 
-# multi->...->exec
-is-deeply $r.multi(), True;
-$r.set("key", "value");
-$r.set("key2", "value2");
-is-deeply $r.exec(), ["OK", "OK"];
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
 
-# multi->...->discard
-is-deeply $r.multi(), True;
-$r.set("key2", "value3");
-is-deeply $r.discard(), True;
-is-deeply $r.get("key2"), "value2";
+
+    # multi->...->exec
+    is-deeply $r.multi(), True;
+    $r.set("key", "value");
+    $r.set("key2", "value2");
+    is-deeply $r.exec(), ["OK", "OK"];
+
+    # multi->...->discard
+    is-deeply $r.multi(), True;
+    $r.set("key2", "value3");
+    is-deeply $r.discard(), True;
+    is-deeply $r.get("key2"), "value2";
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/03-binary.t
+++ b/t/03-binary.t
@@ -4,13 +4,24 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790");
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
 plan 2;
 
-# arbitary binary string 
-my Buf $binary = Buf[uint8].new(1,2,3,129);
-is-deeply $r.set("key", $binary), True;
-is-deeply $r.get("key"), $binary;
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+    my $r = Redis.new("127.0.0.1:63790");
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
+
+
+    # arbitary binary string
+    my Buf $binary = Buf[uint8].new(1,2,3,129);
+    is-deeply $r.set("key", $binary), True;
+    is-deeply $r.get("key"), $binary;
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/03-multibytes.t
+++ b/t/03-multibytes.t
@@ -4,13 +4,26 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
-$r.flushall;
+use Test::SpawnRedisServer;
 
 plan 1;
 
-# bug: multi-bytes chars and \r\n in data
-my $str = "中文 string contains newlines\r\n";
-$r.set("key", $str);
-is-deeply $r.get("key"), $str;
+
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+    $r.flushall;
+
+
+    # bug: multi-bytes chars and \r\n in data
+    my $str = "中文 string contains newlines\r\n";
+    $r.set("key", $str);
+    is-deeply $r.get("key"), $str, "got the right unicode back";
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/04-exec-any-commands.t
+++ b/t/04-exec-any-commands.t
@@ -4,9 +4,21 @@ use lib <t lib>;
 use Redis;
 use Test;
 
-my $r = Redis.new("127.0.0.1:63790", decode_response => True);
-$r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+use Test::SpawnRedisServer;
 
 plan 1;
 
-is-deeply $r.exec_command("CONFIG GET", "timeout"), ["timeout", "1"];
+if SpawnRedis() -> $proc {
+    LEAVE {
+        $proc.kill('INT');
+    }
+
+    my $r = Redis.new("127.0.0.1:63790", decode_response => True);
+    $r.auth('20bdfc8e73365b2fde82d7b17c3e429a9a94c5c9');
+
+
+    is-deeply $r.exec_command("CONFIG GET", "timeout"), ["timeout", "1"];
+}
+else {
+    skip-rest "no redis-server";
+}

--- a/t/Test/SpawnRedisServer.pm
+++ b/t/Test/SpawnRedisServer.pm
@@ -1,7 +1,17 @@
-module Test::SpawnRedisServer;
+unit module Test::SpawnRedisServer;
 
+use File::Which;
 sub SpawnRedis() is export {
-    shell "redis-server t/redis.conf";
+
+    my $proc;
+    if which('redis-server') -> $redis {
+        $proc = Proc::Async.new($redis,'t/redis.conf');
+        $proc.Supply;
+        $proc.start;
+        sleep 2;
+    }
+
+    $proc;
 }
 
 # vim: ft=perl6


### PR DESCRIPTION
Hi,
It seems that over the last couple of years Perl 6 has changed underneath this module.

Three specific areas needed some love:

    * Unreliability of mixing line-oriented and byte oriented reads from sockets.
   *  Addition of append/prepend on lists and removal of flattening from push/unshift
   * Nil is no longer ignored in slurpy arguments.

I've also taken the opportunity to fix #1 by running the redis server for the tests.

All the tests pass.

Thanks for making the module in the first place.
